### PR TITLE
Rename HTTP trait alias fns

### DIFF
--- a/src/routing/service.rs
+++ b/src/routing/service.rs
@@ -153,7 +153,7 @@ where T: HttpFuture,
         loop {
             let catching = match self.state {
                 Pending(ref mut fut) => {
-                    let error = match fut.poll() {
+                    let error = match fut.poll_http() {
                         Ok(Ready(v)) => {
                             let v = v.map(A);
                             return Ok(Ready(v))
@@ -165,7 +165,7 @@ where T: HttpFuture,
                     self.catch.catch(&self.request, error)
                 }
                 Catching(ref mut fut) => {
-                    let resp = try_ready!(HttpFuture::poll(fut))
+                    let resp = try_ready!(HttpFuture::poll_http(fut))
                         .map(|body| B(error::Map::new(body)));
 
                     return Ok(Ready(resp));

--- a/src/run.rs
+++ b/src/run.rs
@@ -77,7 +77,7 @@ where
     fn call(&mut self, request: http::Request<Self::ReqBody>) -> Self::Future {
         let request = request.map(|body| LiftReqBody { body });
         let response = self.inner
-            .call(request)
+            .call_http(request)
             .map(|response| response.map(|body| LiftBody { body }))
             .map_err(|_| unimplemented!())
             ;
@@ -107,7 +107,7 @@ where
                 let h = http.clone();
 
                 tokio::spawn({
-                    new_service.new_service()
+                    new_service.new_http_service()
                         .map_err(|_| unimplemented!())
                         .and_then(move |service| {
                             let service = Lift::new(service);

--- a/src/service/new_service.rs
+++ b/src/service/new_service.rs
@@ -54,7 +54,7 @@ where
     type Future = FutureResult<Self::Service, Self::InitError>;
 
     fn new_service(&self) -> Self::Future {
-        let service = self.middleware.wrap(self.service.clone());
+        let service = self.middleware.wrap_http(self.service.clone());
 
         future::ok(WebService::new(service))
     }

--- a/src/service/web.rs
+++ b/src/service/web.rs
@@ -46,11 +46,11 @@ where
     type Future = <M::Service as HttpService>::Future;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
+        self.inner.poll_http_ready()
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
-        self.inner.call(request)
+        self.inner.call_http(request)
     }
 }
 

--- a/src/util/http/future.rs
+++ b/src/util/http/future.rs
@@ -13,7 +13,7 @@ pub trait HttpFuture: sealed::Sealed {
 
     /// Attempt to resolve the future to a final value, registering the current
     /// task for wakeup if the value is not yet available.
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error>;
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error>;
 
     /// Wraps `self` with `LiftFuture`. This provides an implementation of
     /// `Future` for `Self`.
@@ -35,7 +35,7 @@ where T: Future<Item = http::Response<B>, Error = ::Error>
 {
     type Body = B;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         Future::poll(self)
     }
 }
@@ -50,7 +50,7 @@ impl<T: HttpFuture> Future for LiftFuture<T> {
     type Error = ::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, ::Error> {
-        self.inner.poll()
+        self.inner.poll_http()
     }
 }
 

--- a/src/util/http/middleware.rs
+++ b/src/util/http/middleware.rs
@@ -28,7 +28,7 @@ pub trait HttpMiddleware<S>: sealed::Sealed<S> {
 
     /// Wrap the given service with the middleware, returning a new servicee
     /// that has been decorated with the middleware.
-    fn wrap(&self, inner: S) -> Self::Service;
+    fn wrap_http(&self, inner: S) -> Self::Service;
 }
 
 impl<T, S, B1, B2> HttpMiddleware<S> for T
@@ -42,7 +42,7 @@ where T: Middleware<S, Request = Request<B1>,
     type Error = T::Error;
     type Service = T::Service;
 
-    fn wrap(&self, inner: S) -> Self::Service {
+    fn wrap_http(&self, inner: S) -> Self::Service {
         Middleware::wrap(self, inner)
     }
 }

--- a/src/util/http/new_service.rs
+++ b/src/util/http/new_service.rs
@@ -32,7 +32,7 @@ pub trait NewHttpService: sealed::Sealed {
     type Future: Future<Item = Self::Service, Error = Self::InitError>;
 
     /// Create and return a new service value asynchronously.
-    fn new_service(&self) -> Self::Future;
+    fn new_http_service(&self) -> Self::Future;
 }
 
 impl<T, B1, B2> NewHttpService for T
@@ -48,7 +48,7 @@ where T: NewService<Request = Request<B1>,
     type InitError = T::InitError;
     type Future = T::Future;
 
-    fn new_service(&self) -> Self::Future {
+    fn new_http_service(&self) -> Self::Future {
         NewService::new_service(self)
     }
 }

--- a/src/util/http/service.rs
+++ b/src/util/http/service.rs
@@ -23,10 +23,10 @@ pub trait HttpService: sealed::Service {
     type Future: Future<Item = Response<Self::ResponseBody>, Error = Self::Error>;
 
     /// Returns `Ready` when the service is able to process requests.
-    fn poll_ready(&mut self) -> Poll<(), Self::Error>;
+    fn poll_http_ready(&mut self) -> Poll<(), Self::Error>;
 
     /// Process the request and return the response asynchronously.
-    fn call(&mut self, request: Request<Self::RequestBody>) -> Self::Future;
+    fn call_http(&mut self, request: Request<Self::RequestBody>) -> Self::Future;
 
     /// Wraps `self` with `LiftService`. This provides an implementation of
     /// `Service` for `Self`.
@@ -54,11 +54,11 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn poll_ready(&mut self) -> Poll<(), T::Error> {
+    fn poll_http_ready(&mut self) -> Poll<(), T::Error> {
         Service::poll_ready(self)
     }
 
-    fn call(&mut self, request: Request<Self::RequestBody>) -> Self::Future {
+    fn call_http(&mut self, request: Request<Self::RequestBody>) -> Self::Future {
         Service::call(self, request)
     }
 }
@@ -89,11 +89,11 @@ where T: HttpService,
     type Future = T::Future;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
+        self.inner.poll_http_ready()
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
-        self.inner.call(request)
+        self.inner.call_http(request)
     }
 }
 

--- a/src/util/tuple.rs
+++ b/src/util/tuple.rs
@@ -93,11 +93,11 @@ where
 {
     type Body = Either1<A::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either1::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
         }
     }
 }
@@ -263,12 +263,12 @@ where
 {
     type Body = Either2<A::Body, B::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either2::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
         }
     }
 }
@@ -455,13 +455,13 @@ where
 {
     type Body = Either3<A::Body, B::Body, C::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either3::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
         }
     }
 }
@@ -669,14 +669,14 @@ where
 {
     type Body = Either4<A::Body, B::Body, C::Body, D::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either4::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
         }
     }
 }
@@ -905,15 +905,15 @@ where
 {
     type Body = Either5<A::Body, B::Body, C::Body, D::Body, E::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either5::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
         }
     }
 }
@@ -1163,16 +1163,16 @@ where
 {
     type Body = Either6<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either6::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
         }
     }
 }
@@ -1443,17 +1443,17 @@ where
 {
     type Body = Either7<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either7::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
         }
     }
 }
@@ -1745,18 +1745,18 @@ where
 {
     type Body = Either8<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body, H::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either8::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
-            H(ref mut f) => Ok(try_ready!(f.poll()).map(H).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
+            H(ref mut f) => Ok(try_ready!(f.poll_http()).map(H).into()),
         }
     }
 }
@@ -2069,19 +2069,19 @@ where
 {
     type Body = Either9<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body, H::Body, I::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either9::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
-            H(ref mut f) => Ok(try_ready!(f.poll()).map(H).into()),
-            I(ref mut f) => Ok(try_ready!(f.poll()).map(I).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
+            H(ref mut f) => Ok(try_ready!(f.poll_http()).map(H).into()),
+            I(ref mut f) => Ok(try_ready!(f.poll_http()).map(I).into()),
         }
     }
 }
@@ -2415,20 +2415,20 @@ where
 {
     type Body = Either10<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body, H::Body, I::Body, J::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either10::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
-            H(ref mut f) => Ok(try_ready!(f.poll()).map(H).into()),
-            I(ref mut f) => Ok(try_ready!(f.poll()).map(I).into()),
-            J(ref mut f) => Ok(try_ready!(f.poll()).map(J).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
+            H(ref mut f) => Ok(try_ready!(f.poll_http()).map(H).into()),
+            I(ref mut f) => Ok(try_ready!(f.poll_http()).map(I).into()),
+            J(ref mut f) => Ok(try_ready!(f.poll_http()).map(J).into()),
         }
     }
 }
@@ -2783,21 +2783,21 @@ where
 {
     type Body = Either11<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body, H::Body, I::Body, J::Body, K::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either11::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
-            H(ref mut f) => Ok(try_ready!(f.poll()).map(H).into()),
-            I(ref mut f) => Ok(try_ready!(f.poll()).map(I).into()),
-            J(ref mut f) => Ok(try_ready!(f.poll()).map(J).into()),
-            K(ref mut f) => Ok(try_ready!(f.poll()).map(K).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
+            H(ref mut f) => Ok(try_ready!(f.poll_http()).map(H).into()),
+            I(ref mut f) => Ok(try_ready!(f.poll_http()).map(I).into()),
+            J(ref mut f) => Ok(try_ready!(f.poll_http()).map(J).into()),
+            K(ref mut f) => Ok(try_ready!(f.poll_http()).map(K).into()),
         }
     }
 }
@@ -3173,22 +3173,22 @@ where
 {
     type Body = Either12<A::Body, B::Body, C::Body, D::Body, E::Body, F::Body, G::Body, H::Body, I::Body, J::Body, K::Body, L::Body>;
 
-    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
+    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {
         use self::Either12::*;
 
         match *self {
-            A(ref mut f) => Ok(try_ready!(f.poll()).map(A).into()),
-            B(ref mut f) => Ok(try_ready!(f.poll()).map(B).into()),
-            C(ref mut f) => Ok(try_ready!(f.poll()).map(C).into()),
-            D(ref mut f) => Ok(try_ready!(f.poll()).map(D).into()),
-            E(ref mut f) => Ok(try_ready!(f.poll()).map(E).into()),
-            F(ref mut f) => Ok(try_ready!(f.poll()).map(F).into()),
-            G(ref mut f) => Ok(try_ready!(f.poll()).map(G).into()),
-            H(ref mut f) => Ok(try_ready!(f.poll()).map(H).into()),
-            I(ref mut f) => Ok(try_ready!(f.poll()).map(I).into()),
-            J(ref mut f) => Ok(try_ready!(f.poll()).map(J).into()),
-            K(ref mut f) => Ok(try_ready!(f.poll()).map(K).into()),
-            L(ref mut f) => Ok(try_ready!(f.poll()).map(L).into()),
+            A(ref mut f) => Ok(try_ready!(f.poll_http()).map(A).into()),
+            B(ref mut f) => Ok(try_ready!(f.poll_http()).map(B).into()),
+            C(ref mut f) => Ok(try_ready!(f.poll_http()).map(C).into()),
+            D(ref mut f) => Ok(try_ready!(f.poll_http()).map(D).into()),
+            E(ref mut f) => Ok(try_ready!(f.poll_http()).map(E).into()),
+            F(ref mut f) => Ok(try_ready!(f.poll_http()).map(F).into()),
+            G(ref mut f) => Ok(try_ready!(f.poll_http()).map(G).into()),
+            H(ref mut f) => Ok(try_ready!(f.poll_http()).map(H).into()),
+            I(ref mut f) => Ok(try_ready!(f.poll_http()).map(I).into()),
+            J(ref mut f) => Ok(try_ready!(f.poll_http()).map(J).into()),
+            K(ref mut f) => Ok(try_ready!(f.poll_http()).map(K).into()),
+            L(ref mut f) => Ok(try_ready!(f.poll_http()).map(L).into()),
         }
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -122,7 +122,7 @@ where U: IntoResource<DefaultSerializer, String>,
 
 pub trait TestHttpService: HttpService {
     fn call_unwrap(&mut self, request: http::Request<Self::RequestBody>) -> http::Response<Self::ResponseBody> {
-        self.call(request).wait().ok().unwrap()
+        self.call_http(request).wait().ok().unwrap()
     }
 }
 

--- a/util/gen-tuple.rs
+++ b/util/gen-tuple.rs
@@ -216,13 +216,13 @@ impl Either {
         println!("{{");
         println!("    type Body = Either{}<{}>;", self.level, body_gens);
         println!("");
-        println!("    fn poll(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {{");
+        println!("    fn poll_http(&mut self) -> Poll<http::Response<Self::Body>, ::Error> {{");
         println!("        use self::Either{}::*;", self.level);
         println!("");
         println!("        match *self {{");
 
         for n in 0..self.level {
-            println!("            {}(ref mut f) => Ok(try_ready!(f.poll()).map({}).into()),", VARS[n], VARS[n]);
+            println!("            {}(ref mut f) => Ok(try_ready!(f.poll_http()).map({}).into()),", VARS[n], VARS[n]);
         }
 
         println!("        }}");


### PR DESCRIPTION
This prevents name conflicts with the main traits.

Resolves #60 

cc/ @shepmaster 