### PR TITLE
Add a non-blocking `serve` method to run the server

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 /// A stream between a local and remote target.
 pub trait Connection: AsyncRead + AsyncWrite {
     /// Returns the socket address of the remote peer of this connection.
-    fn peer_addr(&self) -> io::Result<SocketAddr>;
+    fn peer_addr(&self) -> Option<SocketAddr>;
 }
 
 /// An asynchronous stream of connections.
@@ -24,8 +24,8 @@ pub trait ConnectionStream {
 }
 
 impl Connection for TcpStream {
-    fn peer_addr(&self) -> io::Result<SocketAddr> {
-        TcpStream::peer_addr(self)
+    fn peer_addr(&self) -> Option<SocketAddr> {
+        TcpStream::peer_addr(self).ok()
     }
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,7 +9,7 @@ use hyper::server::conn::Http;
 use hyper::service::Service as HyperService;
 
 use tokio;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
 use std::io;
@@ -97,30 +97,44 @@ where
     <T::Service as HttpService>::Future: Send,
 {
     let listener = TcpListener::bind(addr)?;
-    let http = Arc::new(Http::new());
 
-    tokio::run({
-        listener
-            .incoming()
-            .map_err(|e| println!("failed to accept socket; err = {:?}", e))
-            .for_each(move |socket| {
-                let h = http.clone();
-
-                tokio::spawn({
-                    new_service.new_http_service()
-                        .map_err(|_| unimplemented!())
-                        .and_then(move |service| {
-                            let service = Lift::new(service);
-
-                            h.serve_connection(socket, service)
-                                .map(|_| ())
-                                .map_err(|e| {
-                                    println!("failed to serve connection; err={:?}", e);
-                                })
-                        })
-                })
-            })
-    });
+    tokio::run(serve(listener.incoming(), new_service));
 
     Ok(())
+}
+
+/// Returns a future that must be polled to process the incoming connections.
+///
+/// A non-blocking version of `run`.
+pub fn serve<S, T>(incoming: S, new_service: T) -> impl Future<Item = (), Error = ()>
+where
+    S: Stream<Item = TcpStream, Error = io::Error>,
+    T: NewHttpService<RequestBody = LiftReqBody> + Send + 'static,
+    T::Future: Send,
+    <T::ResponseBody as BufStream>::Item: Send,
+    T::ResponseBody: Send,
+    T::Service: Send,
+    <T::Service as HttpService>::Future: Send,
+{
+    let http = Arc::new(Http::new());
+    incoming
+        .map_err(|e| println!("failed to accept socket; err = {:?}", e))
+        .for_each(move |socket| {
+            let h = http.clone();
+
+            tokio::spawn({
+                new_service
+                    .new_http_service()
+                    .map_err(|_| unimplemented!())
+                    .and_then(move |service| {
+                        let service = Lift::new(service);
+
+                        h.serve_connection(socket, service)
+                            .map(|_| ())
+                            .map_err(|e| {
+                                println!("failed to serve connection; err={:?}", e);
+                            })
+                    })
+            })
+        })
 }

--- a/src/service/builder.rs
+++ b/src/service/builder.rs
@@ -1,8 +1,10 @@
 use error::{IntoCatch, DefaultCatch};
+use futures::{Future, Stream};
 use middleware::Identity;
 use response::DefaultSerializer;
 use routing::{Resource, IntoResource, RoutedService};
 use service::NewWebService;
+use tokio::net::TcpStream;
 use util::{BufStream, Chain};
 use util::http::{HttpService, HttpMiddleware};
 
@@ -378,5 +380,26 @@ impl<T, C, M> ServiceBuilder<T, C, M> {
           <T::Resource as Resource>::Future: Send,
     {
         ::run::run(addr, self.build_new_service())
+    }
+
+    /// Run the service in a non-blocking mode.
+    ///
+    /// The returned `Future` object must be polled in order to process the incoming requests.
+    pub fn serve<S>(self, incoming: S) -> impl Future<Item = (), Error = ()>
+    where S: Stream<Item = TcpStream, Error = io::Error>,
+          T: IntoResource<DefaultSerializer, ::run::LiftReqBody>,
+          C: IntoCatch<DefaultSerializer> + Send + 'static,
+          C::Catch: Send,
+          M: HttpMiddleware<RoutedService<T::Resource, C::Catch>, RequestBody = ::run::LiftReqBody> + Send + 'static,
+          M::Service: Send,
+          <M::Service as HttpService>::Future: Send,
+          M::ResponseBody: Send,
+          <M::ResponseBody as BufStream>::Item: Send,
+          T::Resource: Send + 'static,
+          <T::Resource as Resource>::Buf: Send,
+          <T::Resource as Resource>::Body: Send,
+          <T::Resource as Resource>::Future: Send,
+    {
+        ::run::serve(incoming, self.build_new_service())
     }
 }


### PR DESCRIPTION
Hi everyone,

I've been trying to port one of my pet-projects to tower-web, and I was really missing a non-blocking way to start a server (for a proper graceful termination, for instance), so I went ahead and made this PR.

I've made the `serve` methods to accept a stream of connections instead of a pure address so a user could filter out errors while processing incoming connections (like [here](https://docs.rs/futures-retry/0.2.1/futures_retry/trait.StreamRetryExt.html)). I understand the naming is poor, but the most promising `run` name has been already taken :)