### PR TITLE
Add deflate middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,9 @@ serde_urlencoded = "0.5.1"
 tower-web-macros = { version = "0.2.0", path = "tower-web-macros" }
 proc-macro-hack = "0.4.0"
 
+# Deflate middleware
+flate2 = "1.0.2"
+
 [dev-dependencies]
 env_logger = "0.5.12"
+rand = "0.5.5"

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -20,12 +20,16 @@
 ///     curl -v http://localhost:8080/
 
 extern crate env_logger;
+extern crate flate2;
 #[macro_use]
 extern crate tower_web;
 extern crate tokio;
 
 use tower_web::ServiceBuilder;
+use tower_web::middleware::deflate::DeflateMiddleware;
 use tower_web::middleware::log::LogMiddleware;
+
+use flate2::Compression;
 
 #[derive(Clone, Debug)]
 pub struct HelloWorld;
@@ -49,6 +53,7 @@ pub fn main() {
         .resource(HelloWorld)
         // Add middleware, in this case access logging
         .middleware(LogMiddleware::new("hello_world::web"))
+        .middleware(DeflateMiddleware::new(Compression::best()))
         // We run the service
         .run(&addr)
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,6 +439,7 @@
 extern crate atoi;
 extern crate bytes;
 extern crate chrono;
+extern crate flate2;
 #[macro_use]
 extern crate futures;
 extern crate http;

--- a/src/middleware/deflate/middleware.rs
+++ b/src/middleware/deflate/middleware.rs
@@ -1,0 +1,39 @@
+use super::DeflateService;
+use middleware::Middleware;
+use util::buf_stream::BufStream;
+use util::buf_stream::deflate::CompressStream;
+
+use flate2::Compression;
+use http;
+use tower_service::Service;
+
+/// Deflate all response bodies
+#[derive(Debug)]
+pub struct DeflateMiddleware {
+    level: Compression,
+}
+
+impl DeflateMiddleware {
+    /// Create a new `DeflateMiddleware` instance
+    pub fn new(level: Compression) -> DeflateMiddleware {
+        DeflateMiddleware { level }
+    }
+}
+
+impl<S, RequestBody, ResponseBody> Middleware<S> for DeflateMiddleware
+where S: Service<Request = http::Request<RequestBody>,
+                Response = http::Response<ResponseBody>>,
+      RequestBody: BufStream,
+      ResponseBody: BufStream,
+      S::Error: ::std::error::Error,
+{
+    type Request = http::Request<RequestBody>;
+    type Response = http::Response<CompressStream<ResponseBody>>;
+    type Error = S::Error;
+    type Service = DeflateService<S>;
+
+    fn wrap(&self, service: S) -> Self::Service {
+        DeflateService::new(service, self.level)
+    }
+}
+

--- a/src/middleware/deflate/mod.rs
+++ b/src/middleware/deflate/mod.rs
@@ -1,0 +1,7 @@
+//! Middleware that deflates HTTP response bodies
+
+mod middleware;
+mod service;
+
+pub use self::middleware::DeflateMiddleware;
+pub use self::service::{DeflateService, ResponseFuture};

--- a/src/middleware/deflate/service.rs
+++ b/src/middleware/deflate/service.rs
@@ -1,0 +1,76 @@
+use flate2::Compression;
+use futures::{Future, Poll};
+use http;
+use http::header::{CONTENT_ENCODING, HeaderValue};
+use tower_service::Service;
+use util::buf_stream::BufStream;
+use util::buf_stream::deflate::CompressStream;
+
+/// Deflates the inner service's response bodies.
+#[derive(Debug)]
+pub struct DeflateService<S> {
+    inner: S,
+    level: Compression,
+}
+
+/// Deflate the response body.
+#[derive(Debug)]
+pub struct ResponseFuture<T> {
+    inner: T,
+    level: Compression,
+}
+
+impl<S> DeflateService<S> {
+    pub(super) fn new(inner: S, level: Compression) -> DeflateService<S> {
+        DeflateService {
+            inner,
+            level,
+        }
+    }
+}
+
+impl<S, RequestBody, ResponseBody> Service for DeflateService<S>
+where S: Service<Request = http::Request<RequestBody>,
+                Response = http::Response<ResponseBody>>,
+      ResponseBody: BufStream,
+      S::Error: ::std::error::Error,
+{
+    type Request = http::Request<RequestBody>;
+    type Response = http::Response<CompressStream<ResponseBody>>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, request: Self::Request) -> Self::Future {
+        ResponseFuture {
+            inner: self.inner.call(request),
+            level: self.level,
+        }
+    }
+}
+
+impl<T, B> Future for ResponseFuture<T>
+where
+    T: Future<Item = http::Response<B>>,
+    B: BufStream,
+    T::Error: ::std::error::Error,
+{
+    type Item = http::Response<CompressStream<B>>;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let mut response = try_ready!(self.inner.poll())
+            .map(|body| CompressStream::new(body, self.level));
+
+        let content_encoding = HeaderValue::from_static("deflate");
+
+        // Set content-encoding
+        response.headers_mut()
+            .insert(CONTENT_ENCODING, content_encoding);
+
+        Ok(response.into())
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -23,6 +23,7 @@
 //! [log]: log/index.html
 
 pub mod cors;
+pub mod deflate;
 pub mod log;
 
 mod chain;

--- a/src/util/buf_stream/deflate.rs
+++ b/src/util/buf_stream/deflate.rs
@@ -1,0 +1,144 @@
+//! TODO: Dox
+
+use super::{BufStream, SizeHint};
+
+use bytes::{BytesMut, Bytes, Buf, BufMut};
+use flate2::{Compress, Compression, FlushCompress, Status};
+use futures::Poll;
+use futures::Async::*;
+
+use std::cmp;
+use std::io;
+
+/// Compress a buf stream using zlib deflate.
+#[derive(Debug)]
+pub struct CompressStream<T> {
+    // The inner BufStream
+    inner: T,
+
+    // `true` when the inner buffer returned `None`
+    inner_eof: bool,
+
+    // `true` when the deflated stream is complete
+    eof: bool,
+
+    // Buffers input
+    src_buf: BytesMut,
+
+    // Buffers output
+    dst_buf: BytesMut,
+
+    // Compression
+    compress: Compress,
+}
+
+/// Errors returned by `CompressStream`.
+#[derive(Debug)]
+pub struct Error<T> {
+    /// `None` represents a deflate error
+    inner: Option<T>,
+}
+
+const MIN_BUF: usize = 1024;
+
+impl<T> CompressStream<T>
+where T: BufStream,
+{
+    pub fn new(inner: T, level: Compression) -> CompressStream<T> {
+        CompressStream {
+            inner,
+            inner_eof: false,
+            eof: false,
+            src_buf: BytesMut::new(),
+            dst_buf: BytesMut::new(),
+            compress: Compress::new(level, false),
+        }
+    }
+}
+
+impl<T> BufStream for CompressStream<T>
+where T: BufStream,
+{
+    type Item = io::Cursor<Bytes>;
+    type Error = Error<T::Error>;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            if self.eof {
+                return Ok(Ready(None));
+            }
+
+            // First, if needed, try filling the buffer
+            if !self.inner_eof {
+                let res = self.inner.poll()
+                    .map_err(|e| {
+                        Error { inner: Some(e) }
+                    });
+
+                match try_ready!(res) {
+                    Some(buf) => {
+                        self.src_buf.reserve(buf.remaining());
+                        self.src_buf.put(buf);
+                    }
+                    None => {
+                        self.inner_eof = true;
+                    }
+                }
+            }
+
+            let before_out = self.compress.total_out();
+            let before_in = self.compress.total_in();
+
+            let flush = if self.inner_eof {
+                FlushCompress::Finish
+            } else {
+                FlushCompress::None
+            };
+
+            // Ensure the destination buffer has capacity
+            let amt = cmp::max(self.src_buf.len() / 2, MIN_BUF);
+            self.dst_buf.reserve(amt);
+
+            let ret = unsafe {
+                self.compress.compress(
+                    &self.src_buf,
+                    self.dst_buf.bytes_mut(),
+                    flush)
+            };
+
+            let written = (self.compress.total_out() - before_out) as usize;
+            let consumed = (self.compress.total_in() - before_in) as usize;
+
+            unsafe { self.dst_buf.advance_mut(written); }
+            self.src_buf.split_to(consumed);
+
+            match ret {
+                // If we haven't ready any data and we haven't hit EOF yet,
+                // then we need to keep asking for more data because if we
+                // return that 0 bytes of data have been read then it will
+                // be interpreted as EOF.
+                Ok(Status::Ok) | Ok(Status::BufError) if written == 0 && !self.inner_eof => {
+                    continue
+                }
+                Ok(Status::Ok) | Ok(Status::BufError) => {
+                    break;
+                }
+                Ok(Status::StreamEnd) => {
+                    self.eof = true;
+                    break;
+                }
+                Err(..) => {
+                    return Err(Error { inner: None });
+                }
+            }
+        }
+
+        let buf = io::Cursor::new(self.dst_buf.take().freeze());
+        return Ok(Ready(Some(buf)));
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        // TODO: How should this work?
+        self.inner.size_hint()
+    }
+}

--- a/src/util/buf_stream/mod.rs
+++ b/src/util/buf_stream/mod.rs
@@ -14,6 +14,7 @@ mod buf_stream;
 mod bytes;
 mod chain;
 mod collect;
+pub mod deflate;
 mod either;
 mod empty;
 mod file;

--- a/tests/deflate_stream.rs
+++ b/tests/deflate_stream.rs
@@ -1,0 +1,96 @@
+extern crate tower_web;
+extern crate bytes;
+extern crate flate2;
+extern crate futures;
+extern crate rand;
+
+use tower_web::util::buf_stream::BufStream;
+use tower_web::util::buf_stream::deflate::CompressStream;
+
+use bytes::Bytes;
+use futures::{Poll, Future};
+use flate2::Compression;
+use flate2::read::DeflateDecoder;
+use rand::{thread_rng, Rng};
+use rand::distributions::{Distribution, Standard};
+
+use std::cmp;
+use std::io;
+use std::io::prelude::*;
+
+macro_rules! assert_round_trip {
+    ($stream:expr, $expect:expr) => {{
+        let data: Vec<u8> = $stream.collect().wait().unwrap();
+        let mut decoder = DeflateDecoder::new(&data[..]);
+        let mut actual = vec![];
+        decoder.read_to_end(&mut actual).unwrap();
+        assert_eq!(&actual[..], &$expect[..]);
+    }}
+}
+
+#[test]
+fn single_chunk() {
+    let data: Vec<u8> = Standard.sample_iter(&mut thread_rng())
+        .take(16 * 1024)
+        .collect();
+
+    let deflate = CompressStream::new(
+        Mock::single_chunk(data.clone()),
+        Compression::fast());
+
+    assert_round_trip!(deflate, data);
+}
+
+#[test]
+fn multi_chunk() {
+    let data: Vec<u8> = Standard.sample_iter(&mut thread_rng())
+        .take(16 * 1024)
+        .collect();
+
+    let deflate = CompressStream::new(
+        Mock::rand_chunks(data.clone()),
+        Compression::fast());
+
+    assert_round_trip!(deflate, data);
+}
+
+struct Mock {
+    chunks: Vec<Bytes>,
+}
+
+impl Mock {
+    pub fn single_chunk(data: Vec<u8>) -> Mock {
+        Mock { chunks: vec![data.into()] }
+    }
+
+    pub fn rand_chunks(data: Vec<u8>) -> Mock {
+        let mut data = Bytes::from(data);
+        let max = data.len() / 4;
+
+        let mut rng = thread_rng();
+        let mut chunks = vec![];
+
+        while !data.is_empty() {
+            let n = cmp::min(rng.gen_range(1, max), data.len());
+            chunks.push(data.split_to(n));
+        }
+
+        Mock { chunks }
+    }
+}
+
+impl BufStream for Mock {
+    type Item = io::Cursor<Bytes>;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if self.chunks.is_empty() {
+            return Ok(None.into());
+        }
+
+        let chunk = self.chunks.remove(0);
+        let buf = io::Cursor::new(chunk);
+
+        Ok(Some(buf).into())
+    }
+}


### PR DESCRIPTION
This is an initial implementation fo a middleware that deflates all
response bodies. This is added to start experimenting with more advanced
uage of `Middleware` (modifying the response body) and `BufStream`.