### PR TITLE
Percent-decode Strings and PathBufs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = "0.1.6"
 tokio-fs = "0.1.2"
 tokio-io = "0.1.7"
 tower-service = "0.1.0"
+url = "1.7"
 
 # Parsing params
 atoi = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tokio = "0.1.6"
 tokio-fs = "0.1.2"
 tokio-io = "0.1.7"
 tower-service = "0.1.0"
-url = "1.7"
+percent-encoding = "1.0.1"
 
 # Parsing params
 atoi = "0.2.3"

--- a/src/extract/immediate.rs
+++ b/src/extract/immediate.rs
@@ -14,7 +14,10 @@ pub struct Immediate<T> {
 }
 
 impl<T> Immediate<T> {
-    fn new(result: Result<T, Error>) -> Immediate<T> {
+    /// Create a new `Immediate` instance from a `Result` value.
+    ///
+    /// When polling the returned `Immediate` instance, it will yield `result`.
+    pub fn result(result: Result<T, Error>) -> Immediate<T> {
         Immediate {
             inner: result.map_err(Some),
         }
@@ -24,14 +27,14 @@ impl<T> Immediate<T> {
     ///
     /// When polling the returned `Immediate` instance, it will yield `value`.
     pub fn ok(value: T) -> Immediate<T> {
-        Immediate::new(Ok(value))
+        Immediate::result(Ok(value))
     }
 
     /// Create a new `Immediate` instance that is in the error state.
     ///
     /// When polling the returned `Immediate` instance, it will yield `error`.
     pub fn err(error: Error) -> Immediate<T> {
-        Immediate::new(Err(error))
+        Immediate::result(Err(error))
     }
 }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -32,6 +32,7 @@ mod pathbuf;
 #[doc(hidden)]
 pub mod serde;
 mod str;
+mod osstring;
 pub mod http_date_time;
 
 pub use self::error::Error;

--- a/src/extract/osstring.rs
+++ b/src/extract/osstring.rs
@@ -1,16 +1,29 @@
 use extract::{Context, Error, Extract, Immediate};
 use percent_encoding;
 use std::borrow::Cow;
-use util::BufStream;
+use std::ffi::{OsStr, OsString};
+use util::buf_stream::BufStream;
 
-fn decode(s: &str) -> Result<String, Error> {
-    percent_encoding::percent_decode(s.as_bytes())
-        .decode_utf8()
-        .map(Cow::into_owned)
-        .map_err(|e| Error::invalid_argument(&e))
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
+    use std::os::unix::ffi::OsStrExt;
+    Ok(OsStr::from_bytes(bytes))
 }
 
-impl<B: BufStream> Extract<B> for String {
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
+fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
+    use std::str;
+    str::from_utf8(bytes)
+        .map_err(|e| Error::invalid_argument(&e))
+        .map(|s| OsStr::new(s))
+}
+
+fn decode(s: &str) -> Result<OsString, Error> {
+    let percent_decoded = Cow::from(percent_encoding::percent_decode(s.as_bytes()));
+    Ok(osstr_from_bytes(percent_decoded.as_ref())?.to_os_string())
+}
+
+impl<B: BufStream> Extract<B> for OsString {
     type Future = Immediate<Self>;
 
     fn extract(ctx: &Context) -> Self::Future {
@@ -33,7 +46,7 @@ impl<B: BufStream> Extract<B> for String {
 
                 let r = value
                     .to_str()
-                    .map(|s| s.to_string())
+                    .map(OsString::from)
                     .map_err(|e| Error::invalid_argument(&e));
                 Immediate::result(r)
             }
@@ -55,10 +68,16 @@ impl<B: BufStream> Extract<B> for String {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn extract() {
-        assert_eq!("hello, world", decode("hello,%20world").unwrap());
-        assert!(decode("%ff").unwrap_err().is_invalid_argument());
+        assert_eq!(Path::new("hello, world"), decode("hello,%20world").unwrap());
+    }
+
+    #[test]
+    fn disallows_path_traversal() {
+        assert_eq!(decode("foo").unwrap(), OsString::from("foo"));
+        assert_eq!(decode("foo%20bar").unwrap(), OsString::from("foo bar"));
     }
 }

--- a/src/extract/osstring.rs
+++ b/src/extract/osstring.rs
@@ -2,17 +2,11 @@ use extract::{Context, Error, Extract, Immediate};
 use percent_encoding;
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
+use std::str;
 use util::buf_stream::BufStream;
 
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
-    use std::os::unix::ffi::OsStrExt;
-    Ok(OsStr::from_bytes(bytes))
-}
-
-#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
-    use std::str;
+    // NOTE: this is too conservative, as we are rejecting valid paths on Unix
     str::from_utf8(bytes)
         .map_err(|e| Error::invalid_argument(&e))
         .map(|s| OsStr::new(s))

--- a/src/extract/pathbuf.rs
+++ b/src/extract/pathbuf.rs
@@ -1,8 +1,8 @@
 use extract::{Context, Error, Extract, Immediate};
+use percent_encoding;
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::{self, Path, PathBuf};
-use url::percent_encoding;
 use util::buf_stream::BufStream;
 
 #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]

--- a/src/extract/pathbuf.rs
+++ b/src/extract/pathbuf.rs
@@ -1,10 +1,65 @@
-use extract::{Context, Error, Extract, ExtractFuture};
-use futures::Poll;
+use extract::{Context, Error, Extract, Immediate};
+use std::borrow::Cow;
+use std::ffi::OsStr;
 use std::path::{self, Path, PathBuf};
+use url::percent_encoding;
 use util::buf_stream::BufStream;
 
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
+    use std::os::unix::ffi::OsStrExt;
+    Ok(OsStr::from_bytes(bytes))
+}
+
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
+fn osstr_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
+    use std::str;
+    str::from_utf8(bytes)
+        .map_err(|e| Error::invalid_argument(&e))
+        .map(|s| OsStr::new(s))
+}
+
+// https://www.owasp.org/index.php/Path_Traversal
+fn check_for_path_traversal(path: &Path) -> Result<(), Error> {
+    use self::path::Component::*;
+
+    let path_traversal_error = || Error::invalid_argument(&"Path traversal detected");
+
+    let mut depth = 0u32;
+    for c in path.components() {
+        match c {
+            Prefix(_) | RootDir => {
+                // Escaping to the root is immediately a failure
+                Err(path_traversal_error())?
+            }
+            CurDir => {
+                // no-op
+            }
+            ParentDir => {
+                depth = match depth.checked_sub(1) {
+                    Some(v) => v,
+                    None => Err(path_traversal_error())?,
+                }
+            }
+            Normal(_) => {
+                depth += 1;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn decode(s: &str) -> Result<PathBuf, Error> {
+    let percent_decoded = Cow::from(percent_encoding::percent_decode(s.as_bytes()));
+    let path = PathBuf::from(osstr_from_bytes(percent_decoded.as_ref())?);
+
+    check_for_path_traversal(&path)?;
+    Ok(path)
+}
+
 impl<B: BufStream> Extract<B> for PathBuf {
-    type Future = ExtractPathBuf;
+    type Future = Immediate<PathBuf>;
 
     fn extract(ctx: &Context) -> Self::Future {
         use codegen::Source::*;
@@ -12,105 +67,35 @@ impl<B: BufStream> Extract<B> for PathBuf {
         match ctx.callsite().source() {
             Capture(idx) => {
                 let path = ctx.request().uri().path();
-                let value = ctx.captures().get(*idx, path).into();
-                ExtractPathBuf(value)
+                let value = ctx.captures().get(*idx, path);
+
+                Immediate::result(decode(value))
             }
             _ => unimplemented!("A PathBuf can only be extracted from a path capture for now"),
         }
     }
 }
 
-/// Extracts a `PathBuf` value from an HTTP request.
-#[derive(Debug)]
-pub struct ExtractPathBuf(String);
-
-impl ExtractPathBuf {
-    // https://www.owasp.org/index.php/Path_Traversal
-    fn check_for_path_traversal(&self) -> Result<(), Error> {
-        use self::path::Component::*;
-
-        let path_traversal_error = || Error::invalid_argument(&"Path traversal detected");
-
-        let mut depth: u32 = 0;
-        for c in Path::new(&self.0).components() {
-            match c {
-                Prefix(_) | RootDir => {
-                    // Escaping to the root is immediately a failure
-                    return Err(path_traversal_error());
-                }
-                CurDir => {
-                    // no-op
-                }
-                ParentDir => {
-                    depth = match depth.checked_sub(1) {
-                        Some(v) => v,
-                        None => return Err(path_traversal_error()),
-                    }
-                }
-                Normal(_) => {
-                    depth += 1;
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl ExtractFuture for ExtractPathBuf {
-    type Item = PathBuf;
-
-    fn poll(&mut self) -> Poll<(), Error> {
-        self.check_for_path_traversal()?;
-        Ok(().into())
-    }
-
-    fn extract(self) -> Self::Item {
-        PathBuf::from(self.0)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use futures::Async;
     use std::path::Path;
 
     #[test]
     fn extract() {
-        let mut extractor = ExtractPathBuf("hello".into());
-        let poll_state = extractor.poll().expect("extractor failed");
-        assert_eq!(Async::Ready(()), poll_state);
-        assert_eq!(Path::new("hello"), extractor.extract());
+        assert_eq!(Path::new("hello, world"), decode("hello,%20world").unwrap());
     }
 
     #[test]
     fn disallows_path_traversal() {
-        let mut extractor = ExtractPathBuf("..".into());
-        let poll_err = extractor.poll().unwrap_err();
-        assert!(poll_err.is_invalid_argument());
-
-        let mut extractor = ExtractPathBuf("a/..".into());
-        let poll_state = extractor.poll().expect("extractor failed");
-        assert_eq!(Async::Ready(()), poll_state);
-        assert_eq!(Path::new("a/.."), extractor.extract());
-
-        let mut extractor = ExtractPathBuf("../a".into());
-        let poll_err = extractor.poll().unwrap_err();
-        assert!(poll_err.is_invalid_argument());
-
-        let mut extractor = ExtractPathBuf("../a/b".into());
-        let poll_err = extractor.poll().unwrap_err();
-        assert!(poll_err.is_invalid_argument());
-
-        let mut extractor = ExtractPathBuf("a/../b".into());
-        let poll_state = extractor.poll().expect("extractor failed");
-        assert_eq!(Async::Ready(()), poll_state);
-        assert_eq!(Path::new("a/../b"), extractor.extract());
-
-        let mut extractor = ExtractPathBuf("a/b/..".into());
-        let poll_state = extractor.poll().expect("extractor failed");
-        assert_eq!(Async::Ready(()), poll_state);
-        assert_eq!(Path::new("a/b/.."), extractor.extract());
+        assert!(decode("/").unwrap_err().is_invalid_argument());
+        assert!(decode("..").unwrap_err().is_invalid_argument());
+        assert_eq!(decode("a/..").unwrap(), Path::new("a/.."));
+        assert!(decode("../a").unwrap_err().is_invalid_argument());
+        assert!(decode("../a/b").unwrap_err().is_invalid_argument());
+        assert_eq!(decode("a/../b").unwrap(), Path::new("a/../b"));
+        assert_eq!(decode("a/b/..").unwrap(), Path::new("a/b/.."));
+        assert!(decode("%2e%2e").unwrap_err().is_invalid_argument());
+        assert_eq!(decode("a/%2e%2e").unwrap(), Path::new("a/.."));
     }
 }

--- a/src/extract/str.rs
+++ b/src/extract/str.rs
@@ -1,6 +1,6 @@
 use extract::{Context, Error, Extract, Immediate};
+use percent_encoding;
 use std::borrow::Cow;
-use url::percent_encoding;
 use util::BufStream;
 
 fn decode(s: &str) -> Result<String, Error> {

--- a/src/extract/str.rs
+++ b/src/extract/str.rs
@@ -4,8 +4,10 @@ use std::borrow::Cow;
 use util::BufStream;
 
 fn decode(s: &str) -> Result<String, Error> {
-    let percent_decoded = Cow::from(percent_encoding::percent_decode(s.as_bytes())).into_owned();
-    String::from_utf8(percent_decoded).map_err(|e| Error::invalid_argument(&e))
+    percent_encoding::percent_decode(s.as_bytes())
+        .decode_utf8()
+        .map(Cow::into_owned)
+        .map_err(|e| Error::invalid_argument(&e))
 }
 
 impl<B: BufStream> Extract<B> for String {

--- a/src/extract/str.rs
+++ b/src/extract/str.rs
@@ -1,5 +1,12 @@
-use extract::{Extract, Error, Context, Immediate};
+use extract::{Context, Error, Extract, Immediate};
+use std::borrow::Cow;
+use url::percent_encoding;
 use util::BufStream;
+
+fn decode(s: &str) -> Result<String, Error> {
+    let percent_decoded = Cow::from(percent_encoding::percent_decode(s.as_bytes())).into_owned();
+    String::from_utf8(percent_decoded).map_err(|e| Error::invalid_argument(&e))
+}
 
 impl<B: BufStream> Extract<B> for String {
     type Future = Immediate<String>;
@@ -10,10 +17,9 @@ impl<B: BufStream> Extract<B> for String {
         match ctx.callsite().source() {
             Capture(idx) => {
                 let path = ctx.request().uri().path();
-                let value = ctx.captures().get(*idx, path)
-                    .to_string();
+                let value = ctx.captures().get(*idx, path);
 
-                Immediate::ok(value)
+                Immediate::result(decode(value))
             }
             Header(header_name) => {
                 let value = match ctx.request().headers().get(header_name) {
@@ -23,18 +29,16 @@ impl<B: BufStream> Extract<B> for String {
                     }
                 };
 
-                match value.to_str() {
-                    Ok(s) => Immediate::ok(s.to_string()),
-                    Err(_) => Immediate::err(Error::invalid_argument(&"invalid UTF-8 string")),
-                }
+                let r = value
+                    .to_str()
+                    .map(|s| s.to_string())
+                    .map_err(|e| Error::invalid_argument(&e));
+                Immediate::result(r)
             }
             QueryString => {
-                let query = ctx.request().uri()
-                    .path_and_query()
-                    .and_then(|path_and_query| path_and_query.query())
-                    .unwrap_or("");
+                let query = ctx.request().uri().query().unwrap_or("");
 
-                Immediate::ok(query.to_string())
+                Immediate::result(decode(query))
             }
             Body => {
                 unimplemented!();
@@ -43,5 +47,16 @@ impl<B: BufStream> Extract<B> for String {
                 unimplemented!();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn extract() {
+        assert_eq!("hello, world", decode("hello,%20world").unwrap());
+        assert!(decode("%ff").unwrap_err().is_invalid_argument());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,7 @@ extern crate http;
 extern crate hyper;
 #[macro_use]
 extern crate log;
+extern crate percent_encoding;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_plain;
@@ -473,7 +474,6 @@ extern crate tokio;
 extern crate tokio_fs;
 extern crate tokio_io;
 extern crate tower_service;
-extern crate url;
 
 pub mod codegen;
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,7 @@ extern crate tokio;
 extern crate tokio_fs;
 extern crate tokio_io;
 extern crate tower_service;
+extern crate url;
 
 pub mod codegen;
 pub mod config;


### PR DESCRIPTION
The user certainly wants this, and it helps with preventing directory
traversal attacks.

~~The implementation supports arbitrary paths on Unix-like systems, and
valid UTF-8 ones on Windows. I couldn't find a common way of
percent-encoding Windows file paths, but this could potentially be
improved in the future.~~

The implementation doesn't support non-UTF-8 paths.

Fixes #107.