### PR TITLE
add prometheus middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ proc-macro-hack = "0.4.0"
 # Deflate middleware
 flate2 = "1.0.2"
 
+# Prometheus middleware
+prometheus = "0.4"
+
 [dev-dependencies]
 env_logger = "0.5.12"
 rand = "0.5.5"

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -69,7 +69,7 @@ pub fn main() {
         // Add middleware, in this case access logging
         .middleware(LogMiddleware::new("hello_world::web"))
         .middleware(DeflateMiddleware::new(Compression::best()))
-        .middleware(PrometheusMiddleware::new("example", registry))
+        .middleware(PrometheusMiddleware::new(Some("example"), registry))
         // We run the service
         .run(&addr)
         .unwrap();

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -18,27 +18,40 @@
 /// Then send a request:
 ///
 ///     curl -v http://localhost:8080/
-
 extern crate env_logger;
 extern crate flate2;
 #[macro_use]
 extern crate tower_web;
+extern crate prometheus;
 extern crate tokio;
 
-use tower_web::ServiceBuilder;
+use prometheus::{Encoder, Registry, TextEncoder};
 use tower_web::middleware::deflate::DeflateMiddleware;
 use tower_web::middleware::log::LogMiddleware;
+use tower_web::middleware::prometheus::PrometheusMiddleware;
+use tower_web::ServiceBuilder;
 
 use flate2::Compression;
 
-#[derive(Clone, Debug)]
-pub struct HelloWorld;
+#[derive(Clone)]
+pub struct HelloWorld {
+    registry: Registry,
+}
 
 impl_web! {
     impl HelloWorld {
         #[get("/")]
         fn hello_world(&self) -> Result<&'static str, ()> {
             Ok("hello world")
+        }
+
+        #[get("/metrics")]
+        fn metrics(&self) -> Result<String, ()> {
+            let encoder = TextEncoder::new();
+            let metric_families = self.registry.gather();
+            let mut buf = vec![];
+            encoder.encode(&metric_families, &mut buf).unwrap();
+            Ok(std::string::String::from_utf8_lossy(&buf).to_string())
         }
     }
 }
@@ -49,11 +62,14 @@ pub fn main() {
     let addr = "127.0.0.1:8080".parse().expect("Invalid address");
     println!("Listening on http://{}", addr);
 
+    let registry = prometheus::Registry::new();
+
     ServiceBuilder::new()
-        .resource(HelloWorld)
+        .resource(HelloWorld{ registry: registry.clone() })
         // Add middleware, in this case access logging
         .middleware(LogMiddleware::new("hello_world::web"))
         .middleware(DeflateMiddleware::new(Compression::best()))
+        .middleware(PrometheusMiddleware::new("example", registry))
         // We run the service
         .run(&addr)
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc(html_root_url = "https://docs.rs/tower-web/0.2.2")]
-#![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 
 //! Tower Web is a fast web framework that aims to remove boilerplate.
@@ -465,6 +464,8 @@ extern crate http;
 extern crate hyper;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate prometheus;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_plain;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -25,6 +25,7 @@
 pub mod cors;
 pub mod deflate;
 pub mod log;
+pub mod prometheus;
 
 mod chain;
 mod identity;

--- a/src/middleware/prometheus/middleware.rs
+++ b/src/middleware/prometheus/middleware.rs
@@ -15,20 +15,19 @@ pub struct PrometheusMiddleware {
 
 impl PrometheusMiddleware {
     /// Create a new `PrometheusMiddleware` instance.
-    pub fn new(namespace: &'static str, registry: Registry) -> PrometheusMiddleware {
-        let counter_vec_opts =
-            Opts::new("test_counter_vec_d", "test counter vector help").namespace(namespace);
+    pub fn new(namespace: Option<&'static str>, registry: Registry) -> PrometheusMiddleware {
+        let counter_vec_opts = Opts::new("http_requests_total", "Counter of HTTP requests.")
+            .namespace(namespace.unwrap_or(""));
         let counter_vec =
             CounterVec::new(counter_vec_opts, &["path", "statusCode", "method"]).unwrap();
 
         // TODO: Note that histogram doesn't report failures.
         let histogram_opts = histogram_opts!(
-            "test_histogram_opts",
-            "test histogram help",
+            "http_request_duration_seconds",
+            "Histogram of HTTP request duration in seconds.",
             // TODO: Decide on buckets. Expose them to users?
             vec![0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
-        ).namespace(namespace);
-
+        ).namespace(namespace.unwrap_or(""));
         let histogram_vec = HistogramVec::new(histogram_opts, &["path", "method"]).unwrap();
 
         registry.register(Box::new(counter_vec.clone())).unwrap();

--- a/src/middleware/prometheus/middleware.rs
+++ b/src/middleware/prometheus/middleware.rs
@@ -7,19 +7,41 @@ use tower_service::Service;
 
 /// Instrument HTTP calls.
 pub struct PrometheusMiddleware {
-    /// Support prefixing metrics with a namespace.
-    counter_vec: CounterVec,
-    histogram_vec: HistogramVec,
+    requests_total_counter_vec: CounterVec,
+    request_bytes_counter_vec: CounterVec,
+    response_bytes_counter_vec: CounterVec,
+    request_duration_histogram_vec: HistogramVec,
     // TODO: Support switching between histograms and summaries.
 }
 
 impl PrometheusMiddleware {
     /// Create a new `PrometheusMiddleware` instance.
     pub fn new(namespace: Option<&'static str>, registry: Registry) -> PrometheusMiddleware {
-        let counter_vec_opts = Opts::new("http_requests_total", "Counter of HTTP requests.")
-            .namespace(namespace.unwrap_or(""));
-        let counter_vec =
-            CounterVec::new(counter_vec_opts, &["path", "statusCode", "method"]).unwrap();
+        let requests_total_counter_opts =
+            Opts::new("http_requests_total", "Counter of HTTP requests.")
+                .namespace(namespace.unwrap_or(""));
+        let requests_total_counter_vec = CounterVec::new(
+            requests_total_counter_opts,
+            &["path", "statusCode", "method"],
+        ).unwrap();
+
+        let request_bytes_counter_opts = Opts::new(
+            "http_request_bytes_total",
+            "Counter of HTTP request body bytes.",
+        ).namespace(namespace.unwrap_or(""));
+        let request_bytes_counter_vec = CounterVec::new(
+            request_bytes_counter_opts,
+            &["path", "statusCode", "method"],
+        ).unwrap();
+
+        let response_bytes_counter_opts = Opts::new(
+            "http_response_bytes_total",
+            "Counter of HTTP response body bytes.",
+        ).namespace(namespace.unwrap_or(""));
+        let response_bytes_counter_vec = CounterVec::new(
+            response_bytes_counter_opts,
+            &["path", "statusCode", "method"],
+        ).unwrap();
 
         // TODO: Note that histogram doesn't report failures.
         let histogram_opts = histogram_opts!(
@@ -28,14 +50,27 @@ impl PrometheusMiddleware {
             // TODO: Decide on buckets. Expose them to users?
             vec![0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
         ).namespace(namespace.unwrap_or(""));
-        let histogram_vec = HistogramVec::new(histogram_opts, &["path", "method"]).unwrap();
+        let request_duration_histogram_vec =
+            HistogramVec::new(histogram_opts, &["path", "method"]).unwrap();
 
-        registry.register(Box::new(counter_vec.clone())).unwrap();
-        registry.register(Box::new(histogram_vec.clone())).unwrap();
+        registry
+            .register(Box::new(requests_total_counter_vec.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(request_bytes_counter_vec.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(response_bytes_counter_vec.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(request_duration_histogram_vec.clone()))
+            .unwrap();
 
         PrometheusMiddleware {
-            counter_vec,
-            histogram_vec,
+            requests_total_counter_vec,
+            request_bytes_counter_vec,
+            response_bytes_counter_vec,
+            request_duration_histogram_vec,
         }
     }
 }
@@ -53,8 +88,10 @@ where
     fn wrap(&self, service: S) -> Self::Service {
         PrometheusService::new(
             service,
-            self.counter_vec.clone(),
-            self.histogram_vec.clone(),
+            self.requests_total_counter_vec.clone(),
+            self.request_bytes_counter_vec.clone(),
+            self.response_bytes_counter_vec.clone(),
+            self.request_duration_histogram_vec.clone(),
         )
     }
 }

--- a/src/middleware/prometheus/middleware.rs
+++ b/src/middleware/prometheus/middleware.rs
@@ -1,0 +1,39 @@
+use super::PrometheusService;
+use middleware::Middleware;
+
+use http;
+use prometheus::Registry;
+use tower_service::Service;
+
+/// Instrument HTTP calls.
+pub struct PrometheusMiddleware {
+    /// Support prefixing metrics with a namespace.
+    namespace: &'static str,
+    registry: Registry,
+    // TODO: Support switching between histograms and summaries.
+}
+
+impl PrometheusMiddleware {
+    /// Create a new `PrometheusMiddleware` instance.
+    pub fn new(namespace: &'static str, registry: Registry) -> PrometheusMiddleware {
+        PrometheusMiddleware {
+            namespace,
+            registry,
+        }
+    }
+}
+
+impl<S, RequestBody, ResponseBody> Middleware<S> for PrometheusMiddleware
+where
+    S: Service<Request = http::Request<RequestBody>, Response = http::Response<ResponseBody>>,
+    S::Error: ::std::error::Error,
+{
+    type Request = http::Request<RequestBody>;
+    type Response = http::Response<ResponseBody>;
+    type Error = S::Error;
+    type Service = PrometheusService<S>;
+
+    fn wrap(&self, service: S) -> Self::Service {
+        PrometheusService::new(service, self.namespace, &self.registry)
+    }
+}

--- a/src/middleware/prometheus/middleware.rs
+++ b/src/middleware/prometheus/middleware.rs
@@ -2,23 +2,41 @@ use super::PrometheusService;
 use middleware::Middleware;
 
 use http;
-use prometheus::Registry;
+use prometheus::{CounterVec, HistogramVec, Opts, Registry};
 use tower_service::Service;
 
 /// Instrument HTTP calls.
 pub struct PrometheusMiddleware {
     /// Support prefixing metrics with a namespace.
-    namespace: &'static str,
-    registry: Registry,
+    counter_vec: CounterVec,
+    histogram_vec: HistogramVec,
     // TODO: Support switching between histograms and summaries.
 }
 
 impl PrometheusMiddleware {
     /// Create a new `PrometheusMiddleware` instance.
     pub fn new(namespace: &'static str, registry: Registry) -> PrometheusMiddleware {
+        let counter_vec_opts =
+            Opts::new("test_counter_vec_d", "test counter vector help").namespace(namespace);
+        let counter_vec =
+            CounterVec::new(counter_vec_opts, &["path", "statusCode", "method"]).unwrap();
+
+        // TODO: Note that histogram doesn't report failures.
+        let histogram_opts = histogram_opts!(
+            "test_histogram_opts",
+            "test histogram help",
+            // TODO: Decide on buckets. Expose them to users?
+            vec![0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
+        ).namespace(namespace);
+
+        let histogram_vec = HistogramVec::new(histogram_opts, &["path", "method"]).unwrap();
+
+        registry.register(Box::new(counter_vec.clone())).unwrap();
+        registry.register(Box::new(histogram_vec.clone())).unwrap();
+
         PrometheusMiddleware {
-            namespace,
-            registry,
+            counter_vec,
+            histogram_vec,
         }
     }
 }
@@ -34,6 +52,10 @@ where
     type Service = PrometheusService<S>;
 
     fn wrap(&self, service: S) -> Self::Service {
-        PrometheusService::new(service, self.namespace, &self.registry)
+        PrometheusService::new(
+            service,
+            self.counter_vec.clone(),
+            self.histogram_vec.clone(),
+        )
     }
 }

--- a/src/middleware/prometheus/mod.rs
+++ b/src/middleware/prometheus/mod.rs
@@ -1,0 +1,7 @@
+//! Middleware that creates a log entry for each HTTP request.
+
+mod middleware;
+mod service;
+
+pub use self::middleware::PrometheusMiddleware;
+pub use self::service::{PrometheusService, ResponseFuture};

--- a/src/middleware/prometheus/service.rs
+++ b/src/middleware/prometheus/service.rs
@@ -61,6 +61,8 @@ where
         let start = Instant::now();
         let counter_vec = self.counter_vec.clone();
 
+        let size = request.body().length();
+
         ResponseFuture {
             inner,
             method,
@@ -96,8 +98,7 @@ where
                         self.path.path(),
                         response.status().as_str(),
                         self.method.as_str(),
-                    ])
-                    .inc();
+                    ]).inc();
             }
             Err(ref err) => {
                 warn!("ERROR: {}", err);

--- a/src/middleware/prometheus/service.rs
+++ b/src/middleware/prometheus/service.rs
@@ -98,16 +98,6 @@ where
                         self.method.as_str(),
                     ])
                     .inc();
-
-                // info!(
-                //     target: self.target,
-                //     "\"{} {} {:?}\" {} {:?}",
-                //     self.method,
-                //     full_path,
-                //     self.version,
-                //     response.status().as_u16(),
-                //     self.start.elapsed(),
-                // );
             }
             Err(ref err) => {
                 warn!("ERROR: {}", err);

--- a/src/middleware/prometheus/service.rs
+++ b/src/middleware/prometheus/service.rs
@@ -1,0 +1,128 @@
+use futures::{Future, Poll};
+use http;
+use prometheus::{CounterVec, Encoder, HistogramVec, Opts, Registry, TextEncoder};
+use tower_service::Service;
+
+use std::time::Instant;
+
+/// Decorates a service by instrumenting all received requests
+pub struct PrometheusService<S> {
+    inner: S,
+    counter_vec: CounterVec,
+    histogram_vec: HistogramVec,
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct ResponseFuture<T> {
+    inner: T,
+    method: http::Method,
+    path: Option<http::uri::PathAndQuery>,
+    version: http::Version,
+    start: Instant,
+}
+
+impl<S> PrometheusService<S> {
+    pub(super) fn new(
+        inner: S,
+        namespace: &'static str,
+        registry: &Registry,
+    ) -> PrometheusService<S> {
+        let counter_vec_opts =
+            Opts::new("test_counter_vec", "test counter vector help").namespace(namespace);
+        let counter_vec =
+            CounterVec::new(counter_vec_opts, &["path", "statusCode", "method"]).unwrap();
+
+        // TODO: Note that histogram doesn't report failures.
+        let histogram_opts = histogram_opts!(
+            "test_histogram_opts",
+            "test histogram help",
+            // TODO: Decide on buckets. Expose them to users?
+            vec![0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
+        ).namespace(namespace);
+
+        let histogram_vec = HistogramVec::new(histogram_opts, &["path", "method"]).unwrap();
+
+        registry.register(Box::new(counter_vec.clone())).unwrap();
+        registry.register(Box::new(histogram_vec.clone())).unwrap();
+
+        PrometheusService {
+            inner,
+            counter_vec,
+            histogram_vec,
+        }
+    }
+}
+
+impl<S, RequestBody, ResponseBody> Service for PrometheusService<S>
+where
+    S: Service<Request = http::Request<RequestBody>, Response = http::Response<ResponseBody>>,
+    S::Error: ::std::error::Error,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, request: Self::Request) -> Self::Future {
+        let method = request.method().clone();
+        let path = request.uri().path_and_query().map(|p| p.clone());
+        let version = request.version();
+        let start = Instant::now();
+
+        let inner = self.inner.call(request);
+
+        ResponseFuture {
+            inner,
+            method,
+            path,
+            version,
+            start,
+        }
+    }
+}
+
+impl<T, B> Future for ResponseFuture<T>
+where
+    T: Future<Item = http::Response<B>>,
+    T::Error: ::std::error::Error,
+{
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        use futures::Async::*;
+
+        let res = self.inner.poll();
+
+        match res {
+            Ok(Ready(ref response)) => {
+                let full_path = self.path.as_ref().map(|p| p.as_str()).unwrap_or("/");
+
+                let elapsed = self.start;
+
+                // TODO: Instrument response
+
+                // info!(
+                //     target: self.target,
+                //     "\"{} {} {:?}\" {} {:?}",
+                //     self.method,
+                //     full_path,
+                //     self.version,
+                //     response.status().as_u16(),
+                //     self.start.elapsed(),
+                // );
+            }
+            Err(ref err) => {
+                warn!("ERROR: {}", err);
+            }
+            _ => {}
+        }
+
+        res
+    }
+}


### PR DESCRIPTION
requested in #44 

This is a work-in-progress, but because I'm a very green rust developer, I'm opening the PR so I can get some help/direction (edits from maintainers is allowed, too -- so feel free to change things).

Questions:
- `derive(Debug)` is required, but it appears the types in the `prometheus` crate don't implement this themselves, so I'm not sure how best to handle this -- add it upstream to the crate?
- `PrometheusMiddleware::new` accepts an optional str as its first argument, to namespace the metrics. How would the idea of an optional config value be best expressed? I wasn't sure if there should be a middleware builder, or this optional route, or ...
- On that note, there are several knobs that can be tweaked (e.g. the histogram buckets, whether to use a Summary or a Histogram [two different types of prometheus metrics]), and I wasn't sure what to expose vs. what to set for the user to maintain a simple API
- The request and response body seem to be an unbounded generic, so I'm not sure how to get the length of the body for either (which can be a useful metric)

I'm happy to hear any suggestions on API changes, as I have very little experience in what should or should not be done for rust (or the direction you want this project you go).

Sorry for dropping a half-done PR on you, but I would be happy to keep working on it with a little guidance, or to hand the PR over if that would save you the time.