### PR TITLE
Add experimental async/await support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - rust: stable
     - rust: nightly
     # minimum rustc version
-    - rust: 1.26.0
+    - rust: 1.29.0
       script: cargo build
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ members = [
 ]
 
 [features]
+# This feature comes with no promise of stability. Things will
+# break with each patch release. Use at your own risk.
+async-await-preview = [
+  "tokio/async-await-preview",
+  "tokio-async-await/async-await-preview",
+  "futures/nightly",
+]
 default = ["handlebars"]
 
 [dependencies]
@@ -60,7 +67,11 @@ proc-macro-hack = "0.4.0"
 # Deflate middleware
 flate2 = "1.0.2"
 
+# Handlebars support
 handlebars = { version = "1.0.3", optional = true }
+
+# async/await support
+tokio-async-await = { version = "0.1.4", optional = true }
 
 [dev-dependencies]
 env_logger = "0.5.12"

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,3 +31,25 @@ order:
 
 * [`html_handlebars`](html_handlebars.rs) - Respond with HTML by rendering
   handlebars templates.
+
+Tower Web provides experimental support for Rust's `async` / `await`
+syntax. To use this syntax, the Rust nightly release channel is required
+and the crate must be set to the 2018 edition.
+
+The example in the [`async-await`] directory contains a [`Cargo.toml`]
+as well as code.
+
+1) Add [`edition = 2018`][2018] to your `Cargo.toml`.
+2) Add [`features = ["async-await-preview"]`][feature] to the
+`tower-web` dependency.
+3) Use the necessary [nightly features] in the application.
+4) Import Tokio's [`await!` macro][await].
+5) Define [`async`][async-handler] handlers.
+
+[`async-await`]: async-await
+[`Cargo.toml`]: async-await/Cargo.toml
+[2018]: async-await/Cargo.toml
+[feature]: async-await/Cargo.toml
+[nightly features]: async-await/src/hyper.rs#L22
+[await]: async-await/src/hyper.rs#L30
+[async-handler]: async-await/src/hyper.rs#L54

--- a/examples/async-await/.cargo/config
+++ b/examples/async-await/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../../target"

--- a/examples/async-await/Cargo.toml
+++ b/examples/async-await/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "examples-async-await"
+edition = "2018"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+
+# Used to escape the parent workspace. This crate uses edition 2018 and the
+# parent does not.
+[workspace]
+
+[[bin]]
+name = "hyper"
+path = "src/hyper.rs"
+
+[dependencies]
+tower-web = { version = "0.2.2", path = "../..", features = ["async-await-preview"] }
+tokio = "0.1.10"
+hyper = "0.12.10"
+futures = "0.1.18"

--- a/examples/async-await/src/hyper.rs
+++ b/examples/async-await/src/hyper.rs
@@ -1,0 +1,98 @@
+//! Service with async/await handlers.
+//!
+//! A service that demonstrates how to use Tower Web's experimental support for the upcoming
+//! async/await syntax.
+//!
+//! # Overview
+//!
+//! async/await enables easier writing of asynchronous code. Handler functions are prefaced with
+//! the `async` keyword. The async fn implementation may then use `await!` and call other `async`
+//! functions. It requires using the Rust nightly channel as well as opting into unstable features.
+//!
+//! ## Usage
+//!
+//! From within the `examples/async-await` directory, run the example:
+//!
+//!     cargo +nightly run --bin hyper
+//!
+//! Then send a request:
+//!
+//!     curl -v http://localhost:8080/
+
+#![feature(await_macro, async_await, futures_api)]
+
+#[macro_use]
+extern crate tower_web;
+extern crate tokio;
+extern crate hyper;
+
+use tokio::prelude::*;
+use tokio::await;
+use tower_web::ServiceBuilder;
+
+use std::str;
+
+// The HTTP client
+type HttpClient = hyper::Client<hyper::client::HttpConnector>;
+
+/// This type will be part of the web service as a resource.
+#[derive(Clone, Debug)]
+pub struct HelloWorld {
+    client: HttpClient,
+}
+
+/// To derive `Resource`, the implementation of `HelloWorld` is contained in the
+/// `impl_web!` macro. This macro does not modify any of its contents. It will
+/// inspect the implementation and, with the help of some annotations, generate
+/// the necessary glue code to run the web service.
+///
+/// impl_web! is a temporary solution to enable tower-web to work with stable
+/// rust. In the near future, this will be transitioned to use attribute macros.
+impl_web! {
+    impl HelloWorld {
+        #[get("/")]
+        async fn hello_world(&self) -> String {
+            // Get the URI of the server by issuing a query to `/ip`.
+            let uri = "http://httpbin.org/ip".parse().unwrap();
+
+            // Issue the request and wait for the response
+            let response = await!(self.client.get(uri)).unwrap();
+
+            // Get the body component of the HTTP response. This is a stream and as such, it must
+            // be asynchronously collected.
+            let mut body = response.into_body();
+
+            // The body chunks will be appended to this string.
+            let mut ret = String::new();
+
+            while let Some(chunk) = await!(body.next()) {
+                let chunk = chunk.unwrap();
+
+                // Convert to a string
+                let chunk = str::from_utf8(&chunk[..]).unwrap();
+
+                // Append to buffer
+                ret.push_str(chunk);
+            }
+
+            // Return the collected string
+            ret
+        }
+    }
+}
+
+pub fn main() {
+    // Next, we must run our web service.
+    //
+    // The HTTP service will listen on this address and port.
+    let addr = "127.0.0.1:8080".parse().expect("Invalid address");
+    println!("Listening on http://{}", addr);
+
+    // A service builder is used to configure our service.
+    ServiceBuilder::new()
+        .resource(HelloWorld {
+            client: hyper::Client::new(),
+        })
+        .run(&addr)
+        .unwrap();
+}

--- a/examples/catch.rs
+++ b/examples/catch.rs
@@ -14,12 +14,12 @@ struct Buggy;
 impl_web! {
     impl Buggy {
         #[get("/")]
-        fn index(&self) -> impl Future<Item = String, Error = ()> + Send {
+        fn index(&self) -> impl Future<Item = String, Error = ()> {
             Err(()).into_future()
         }
 
         #[catch]
-        fn catch_error(&self) -> impl Future<Item = String, Error = io::Error> + Send {
+        fn catch_error(&self) -> impl Future<Item = String, Error = io::Error> {
             Ok("hello".to_string()).into_future()
         }
     }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -99,12 +99,11 @@ impl_web! {
         // Here a future is used to generate the response. This allows for
         // asynchronous processing of the request.
         //
-        // Note that `impl Future` is bound by `Send`. Currently, hyper
-        // requires everything to be `Send`. So, in order to run our service, we
-        // also have to guarantee that everything is Send.
+        // Note that the returned future must impl `Send`. Currently, hyper
+        // requires everything to be `Send`.
         //
         #[get("/hello-future")]
-        fn hello_future(&self) -> impl Future<Item = String, Error = ()> + Send {
+        fn hello_future(&self) -> impl Future<Item = String, Error = ()> {
             future::ok("Or return a future that resolves to the response".to_string())
         }
 

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -32,7 +32,7 @@ impl_web! {
     impl SelfServing {
         #[get("/")]
         #[content_type("plain")]
-        fn index(&self) -> impl Future<Item = File, Error = io::Error> + Send {
+        fn index(&self) -> impl Future<Item = File, Error = io::Error> {
             let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             path.push(file!());
             File::open(path)
@@ -47,7 +47,7 @@ impl_web! {
         //
         #[get("/unsafe-files/*relative_path")]
         #[content_type("plain")]
-        fn unsafe_files(&self, relative_path: String) -> impl Future<Item = File, Error = io::Error> + Send {
+        fn unsafe_files(&self, relative_path: String) -> impl Future<Item = File, Error = io::Error> {
             let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             // String does no checks for path traversal; do not use this in production!
             path.push(relative_path);
@@ -60,7 +60,7 @@ impl_web! {
         //
         #[get("/files/*relative_path")]
         #[content_type("plain")]
-        fn files(&self, relative_path: PathBuf) -> impl Future<Item = File, Error = io::Error> + Send {
+        fn files(&self, relative_path: PathBuf) -> impl Future<Item = File, Error = io::Error> {
             let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             path.push(relative_path);
             File::open(path)

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -29,3 +29,31 @@ pub mod futures {
 pub mod serde {
     pub use serde::*;
 }
+
+#[cfg(feature = "async-await-preview")]
+pub mod async_await {
+    use futures::Future;
+
+    use std::future::{Future as StdFuture};
+
+    /// Converts a `std::future::Future` to a boxed stable future.
+    ///
+    /// This bridges async/await with stable futures.
+    pub fn async_to_box_future_send<T>(future: T)
+        -> Box<Future<Item = T::Output, Error = ::Error> + Send>
+    where
+        T: StdFuture + Send + 'static,
+    {
+        use tokio_async_await::compat::backward;
+
+        let future = backward::Compat::new(map_ok(future));
+        Box::new(future)
+    }
+
+    async fn map_ok<T, E>(future: T) -> Result<T::Output, E>
+    where
+        T: StdFuture,
+    {
+        Ok(await!(future))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 #![doc(html_root_url = "https://docs.rs/tower-web/0.2.2")]
 #![deny(missing_debug_implementations, missing_docs)]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(feature = "async-await-preview", feature(
+        async_await,
+        await_macro,
+        futures_api,
+        ))]
 
 //! Tower Web is a fast web framework that aims to remove boilerplate.
 //!
@@ -478,6 +483,9 @@ extern crate void;
 
 #[cfg(feature = "handlebars")]
 extern crate handlebars;
+
+#[cfg(feature = "async-await-preview")]
+extern crate tokio_async_await;
 
 pub mod codegen;
 pub mod config;

--- a/tower-web-macros/src/resource/catch.rs
+++ b/tower-web-macros/src/resource/catch.rs
@@ -34,7 +34,7 @@ impl Catch {
         });
 
         self.sig.dispatch(
-            quote!(self.handler),
+            quote!(self.inner),
             args)
     }
 }

--- a/tower-web-macros/src/resource/parse.rs
+++ b/tower-web-macros/src/resource/parse.rs
@@ -86,6 +86,9 @@ impl syn::fold::Fold for ImplWeb {
         // Get the method name
         let ident = item.sig.ident.clone();
 
+        // Track if an async function
+        let is_async = item.sig.asyncness.is_some();
+
         // Get the return type
         let ret = match item.sig.decl.output {
             ReturnType::Type(_, ref ty) => (**ty).clone(),
@@ -124,15 +127,15 @@ impl syn::fold::Fold for ImplWeb {
             }
         }
 
+        let sig = Signature::new(ident, ret, args, is_async);
+
         if attributes.is_route() {
             let index = self.resource().routes.len();
-            let sig = Signature::new(ident, ret, args);
             let route = Route::new(index, sig, attributes);
 
             self.resource().routes.push(route);
         } else {
             let index = self.resource().catches.len();
-            let sig = Signature::new(ident, ret, args);
             let catch = Catch::new(index, sig, attributes);
 
             self.resource().catches.push(catch);


### PR DESCRIPTION
This is based on Tokio's async/await support. Resources may annotate
`async` functions as response handlers.