### PR TITLE
Fix serde extract panic

### DIFF
--- a/src/extract/error.rs
+++ b/src/extract/error.rs
@@ -44,7 +44,7 @@ impl Error {
         }
     }
 
-    fn web(err: ::Error) -> Error {
+    pub(crate) fn web(err: ::Error) -> Error {
         Error { kind: Web(err) }
     }
 

--- a/src/extract/serde.rs
+++ b/src/extract/serde.rs
@@ -111,10 +111,18 @@ where T: DeserializeOwned,
                             
                             SerdeFuture { state, is_json: false }   
                         }
-                        _ => panic!("Unknown content type")
+                        _ => {
+                            let err = Error::web(::Error::from(::error::ErrorKind::bad_request()));
+                            let state = State::Complete(Err(Some(err)));
+
+                            SerdeFuture { state, is_json: false }
+                        }
                     } 
                 } else {
-                    panic!("Content-Type header not present")
+                    let err = Error::web(::Error::from(::error::ErrorKind::bad_request()));
+                    let state = State::Complete(Err(Some(err)));
+
+                    SerdeFuture { state, is_json: false }
                 }
             }
             Unknown => {

--- a/src/extract/serde.rs
+++ b/src/extract/serde.rs
@@ -86,13 +86,13 @@ where T: DeserializeOwned,
 
         match ctx.callsite().source() {
             Capture(_) => {
-                unimplemented!();
+                unimplemented!("Capture");
             }
             Header(_) => {
-                unimplemented!();
+                unimplemented!("Header");
             }
             QueryString => {
-                unimplemented!();
+                unimplemented!("QueryString");
             }
             Body => {
                 use http::header;
@@ -114,11 +114,11 @@ where T: DeserializeOwned,
                         _ => panic!("Unknown content type")
                     } 
                 } else {
-                    panic!()
+                    panic!("Content-Type header not present")
                 }
             }
             Unknown => {
-                unimplemented!();
+                unimplemented!("Unknown");
             }
         }
     }

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -138,6 +138,16 @@ fn extract_body_wrap_json_success() {
 }
 
 #[test]
+fn extract_body_wrap_json_no_content_type_header() {
+    let mut web = service(TestExtract);
+
+    let body = "";
+
+    let response = web.call_unwrap(post!("/extract_body", body));
+    assert_bad_request!(response);
+}
+
+#[test]
 fn extract_x_www_form_urlencoded() {
     let mut web = service(TestExtract);
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -54,7 +54,7 @@ macro_rules! assert_ok {
 
 macro_rules! assert_bad_request {
     ($response:expr) => {
-        assert_eq!($response.status(), ::http::StatusCode::OK)
+        assert_eq!($response.status(), ::http::StatusCode::BAD_REQUEST)
     }
 }
 


### PR DESCRIPTION
`curl -X PUT localhost:8080/api` to an endpoint with a body extract was panicking. This was fixed by returning a bad request error.

I would like to add a test for the new behavior; can you please advise?