### PR TITLE
Allow templates to be loaded without Cargo env

### DIFF
--- a/src/view/handlebars.rs
+++ b/src/view/handlebars.rs
@@ -6,7 +6,7 @@ use http::header::HeaderValue;
 use serde::Serialize;
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR};
 use std::sync::Arc;
 
 /// Serialize response values using Handlebars templates
@@ -30,17 +30,60 @@ impl Handlebars {
     /// `#[derive(Response)]` and a template name specified using the
     /// `#[web(template = "<template name>")]`.
     ///
-    /// Templates are loaded from the `templates` directory in the crate root
-    /// and have the `.hbs` file extension.
+    /// Templates are loaded from one of the following locations, checked in order:
+    ///
+    /// 1. A `templates` directory under the `TOWER_WEB_TEMPLATE_DIR` environment variable
+    /// 2. A `templates` directory under the crate root (`CARGO_MANIFEST_DIR` environment variable)
+    /// 3. A `templates` directory under the current working directory.
+    ///
+    /// Templates have the `.hbs` file extension.
+    ///
+    /// For more control over how templates are loaded, use
+    /// [`new_with_registry`](struct.Handlebars.html#method.new_with_registry).
     pub fn new() -> Handlebars {
         let mut registry = Registry::new();
 
-        if let Ok(value) = env::var("CARGO_MANIFEST_DIR") {
-            let dir = Path::new(&value).join("templates");
+        let mut registered = false;
 
+        // 1. $TOWER_WEB_TEMPLATE_DIR/templates
+        if let Ok(value) = env::var("TOWER_WEB_TEMPLATE_DIR") {
+            let base_dir = Path::new(&value);
+
+            if !base_dir.exists() {
+                panic!("TOWER_WEB_TEMPLATE_DIR was set but {:?} does not exist", base_dir);
+            }
+
+            let template_dir = base_dir.join("templates");
+
+            if !template_dir.exists() {
+                panic!("TOWER_WEB_TEMPLATE_DIR was set but the template directory {:?} does not exist", template_dir);
+            }
+            registry.register_templates_directory(".hbs", template_dir).unwrap();
+            registered = true;
+        }
+        if !registered {
+            // 2. A 'templates' folder under the crate root
+            if let Ok(value) = env::var("CARGO_MANIFEST_DIR") {
+                let dir = Path::new(&value).join("templates");
+
+                if dir.exists() {
+                    registry.register_templates_directory(".hbs", dir).unwrap();
+                    registered = true;
+                }
+            }
+        }
+        if !registered {
+            // 3. A 'templates' folder under the current working directory
+            let dir = Path::new("templates");
             if dir.exists() {
                 registry.register_templates_directory(".hbs", dir).unwrap();
+                registered = true;
             }
+        }
+
+        if !registered {
+            let pwd = Path::new(&env::current_dir().unwrap()).join("templates");
+            panic!("A templates directory was not found. Registering Handlebars failed. Checked at $TOWER_WEB_TEMPLATE_DIR{}templates, $CARGO_MANIFEST_DIR{}templates (crate root), and {:?} (under the current working directory).", MAIN_SEPARATOR, MAIN_SEPARATOR, pwd);
         }
 
         Handlebars::new_with_registry(registry)


### PR DESCRIPTION
Add locations to look for a templates directory when using
`view::Handlebars::new()`.

Previously, this would only look at the environment variable
`CARGO_MANIFEST_DIR`, which is only set when run using `cargo`. This
makes it hard to deploy an application that uses handlebars templates.

This change introduces a chain of places to check for a templates
directory.

1. A `templates` directory under the `TOWER_WEB_TEMPLATE_DIR` environment variable
2. A `templates` directory under the crate root (`CARGO_MANIFEST_DIR` environment variable)
3. A `templates` directory under the current working directory.

This commit also adds an improved error message when one of these
locations does not exist when the handlebars location is registered.
This is a small breaking change because previously an application would
not `panic!` if the `templates` directory did not exist on application
startup.

Fixes #127 and #136