### PR TITLE
Generic resource impl

### DIFF
--- a/tests/resource.rs
+++ b/tests/resource.rs
@@ -1,7 +1,11 @@
+#![recursion_limit="256"]
+
 extern crate futures;
 extern crate http;
 #[macro_use]
 extern crate tower_web;
+
+use std::fmt::Display;
 
 #[macro_use]
 mod support;
@@ -9,6 +13,18 @@ use support::*;
 
 #[derive(Clone, Debug)]
 struct TestResource;
+
+#[derive(Clone, Debug)]
+struct HelloWorld<S>(S);
+
+#[derive(Clone, Debug)]
+struct WhereHelloWorld<S>(S);
+
+#[derive(Clone, Debug)]
+struct EmptyGeneric<S>(S);
+
+#[derive(Clone, Debug)]
+struct EmptyWhere<S>(S);
 
 impl_web! {
     impl TestResource {
@@ -19,6 +35,32 @@ impl_web! {
             Ok("impl_future").into_future()
         }
     }
+
+    impl<S: Display> HelloWorld<S> {
+        #[get("/")]
+        fn hello(&self) -> Result<String, ()> {
+            let r = self.0.to_string();
+            Ok(r)
+        }
+    }
+
+    impl<S> WhereHelloWorld<S>
+    where
+        S: Display,
+    {
+        #[get("/")]
+        fn hello(&self) -> Result<String, ()> {
+            let r = self.0.to_string();
+            Ok(r)
+        }
+    }
+
+    // Just make sure this compiles
+    impl<S> EmptyGeneric<S> {
+    }
+
+    impl<S> EmptyWhere<S> where S: Display {
+    }
 }
 
 #[test]
@@ -28,4 +70,19 @@ fn impl_future() {
     let response = web.call_unwrap(get!("/impl_future"));
     assert_ok!(response);
     assert_body!(response, "impl_future");
+}
+
+#[test]
+fn generic() {
+    let mut web = service(HelloWorld("hello"));
+
+    let response = web.call_unwrap(get!("/"));
+    assert_ok!(response);
+    assert_body!(response, "hello");
+
+    let mut web = service(WhereHelloWorld("hello"));
+
+    let response = web.call_unwrap(get!("/"));
+    assert_ok!(response);
+    assert_body!(response, "hello");
 }

--- a/tower-web-macros/src/resource/parse.rs
+++ b/tower-web-macros/src/resource/parse.rs
@@ -65,8 +65,20 @@ impl syn::fold::Fold for ImplWeb {
             "trait impls must not be in impl_web! block"
         );
 
+        // The resource may only have type generics (for now at least).
+        for param in &item.generics.params {
+            use syn::GenericParam::Type;
+
+            match *param {
+                Type(_) => {}
+                ref actual => {
+                    panic!("Resources may only have generic type parameters. Actual = {:?}", actual);
+                }
+            }
+        }
+
         let index = self.resources.len();
-        self.resources.push(Resource::new(index, item.self_ty.clone()));
+        self.resources.push(Resource::new(index, &item));
 
         syn::fold::fold_item_impl(self, item)
     }

--- a/tower-web-macros/src/resource/ty_tree.rs
+++ b/tower-web-macros/src/resource/ty_tree.rs
@@ -67,11 +67,11 @@ impl<'a> TyTree<'a, Arg> {
                         &callsites.#index.0);
 
                     if callsites.#index.1 {
-                        <#ty as __tw::extract::Extract<B>>::extract_body(
+                        <#ty as __tw::extract::Extract<__B>>::extract_body(
                             &context,
                             body.take().unwrap())
                     } else {
-                        <#ty as __tw::extract::Extract<B>>::extract(&context)
+                        <#ty as __tw::extract::Extract<__B>>::extract(&context)
                     }
                 }}
             },


### PR DESCRIPTION
The impl_web macro did not generate correct output when the target
resource type included generics.

This patch adds support for generics.

Fixes #141