### PR TITLE
Implement Response for Option and Vec

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -28,11 +28,13 @@ mod default_serializer;
 mod either;
 mod file;
 mod json;
+mod option;
 mod response;
 mod serde;
 mod serializer;
 mod serializer_context;
 mod str;
+mod vec;
 
 pub use self::content_type::ContentType;
 pub use self::context::Context;

--- a/src/response/option.rs
+++ b/src/response/option.rs
@@ -1,0 +1,16 @@
+use super::{Context, Response, Serializer};
+use error::ErrorKind;
+
+use http;
+
+impl<T: Response> Response for Option<T> {
+    type Buf = T::Buf;
+    type Body = T::Body;
+
+    fn into_http<S: Serializer>(self, context: &Context<S>) -> Result<http::Response<Self::Body>, ::Error> {
+        match self {
+            Some(inner) => Response::into_http(inner, context),
+            None => Err(ErrorKind::not_found().into()),
+        }
+    }
+}

--- a/src/response/vec.rs
+++ b/src/response/vec.rs
@@ -1,0 +1,19 @@
+use response::{Response, Serializer, Context, SerdeResponse};
+
+use http;
+use serde;
+
+impl<T> Response for Vec<T>
+where
+    T: serde::Serialize,
+{
+    type Buf = <SerdeResponse<Self> as Response>::Buf;
+    type Body = <SerdeResponse<Self> as Response>::Body;
+
+    fn into_http<S>(self, context: &Context<S>) -> Result<http::Response<Self::Body>, ::Error>
+    where
+        S: Serializer,
+    {
+        Response::into_http(SerdeResponse::new(self), context)
+    }
+}


### PR DESCRIPTION
* Returning `None` results in a 404.
* Vec is forwarded to Serde's implementation.

Fixes #146