### PR TITLE
Fix a Clippy warning inside Response macro

### DIFF
--- a/tower-web-macros/src/derive/response.rs
+++ b/tower-web-macros/src/derive/response.rs
@@ -312,7 +312,7 @@ impl Response {
                             .unwrap()
                             .or_insert_with(|| {
                                 context.content_type_header()
-                                    .map(|content_type| content_type.clone())
+                                    .cloned()
                                     .unwrap_or_else(|| {
                                         __tw::codegen::http::header::HeaderValue::from_static("application/octet-stream")
                                     })


### PR DESCRIPTION
I noticed that Clippy complains about this case for almost all projects which use `tower-web`, which can be quite annoying. Since the fix is tiny, I figured it wouldn't hurt to file this!