### PR TITLE
Pin atoi version to patch release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tower-service = "0.1.0"
 void = "1.0.2"
 
 # Parsing params
-atoi = "0.2.3"
+atoi = "= 0.2.3"
 checked = "0.5.0"
 chrono = "0.4.4"
 

--- a/src/error/error.rs
+++ b/src/error/error.rs
@@ -68,10 +68,10 @@ impl fmt::Debug for Error {
 }
 
 impl fmt::Display for Error {
+    #[allow(deprecated)] // .cause() is deprecated on nightly
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;
 
-        #[allow(deprecated)] // .cause() is deprecated on nightly
         if let Some(cause) = self.cause() {
             write!(fmt, "{}: {}", self.description(), cause)
         } else {

--- a/src/error/error.rs
+++ b/src/error/error.rs
@@ -71,6 +71,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;
 
+        #[allow(deprecated)] // .cause() is deprecated on nightly
         if let Some(cause) = self.cause() {
             write!(fmt, "{}: {}", self.description(), cause)
         } else {


### PR DESCRIPTION
Atoi switched to Rust 2018 in a patch release, which broke backwards
compat with older Rust versions.