### PR TITLE
Increase max variants from 3 to 12

### DIFF
--- a/tower-web-macros/src/lib.rs
+++ b/tower-web-macros/src/lib.rs
@@ -15,7 +15,7 @@ mod resource;
 
 use proc_macro::TokenStream;
 
-const MAX_VARIANTS: usize = 3;
+const MAX_VARIANTS: usize = 12;
 
 proc_macro_item_impl! {
     /// Implement a Web Service

--- a/tower-web-macros/src/resource/resource.rs
+++ b/tower-web-macros/src/resource/resource.rs
@@ -888,6 +888,15 @@ fn variant(index: usize, max: usize) -> TokenStream {
         0 => quote! { #either::A },
         1 => quote! { #either::B },
         2 => quote! { #either::C },
+        3 => quote! { #either::D },
+        4 => quote! { #either::E },
+        5 => quote! { #either::F },
+        6 => quote! { #either::G },
+        7 => quote! { #either::H },
+        8 => quote! { #either::I },
+        9 => quote! { #either::J },
+        10 => quote! { #either::K },
+        11 => quote! { #either::L },
         n => panic!("unimplemented; variant {}", n),
     }
 }


### PR DESCRIPTION
Quick improvement for #106. I tried to find a more general solution, but it seems to need quite a bit of refactoring. 

Is there a reason to not bump this up? [gen-tuple](https://github.com/carllerche/tower-web/blob/master/util/gen-tuple.rs#L2-L14) is already generating all of these variants.


