### PR TITLE
fix(handlebars) stick handlebars version to 1.0.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ flate2 = "1.0.2"
 tokio-rustls = { version = "0.8.0", optional = true }
 
 # Handlebars support
-handlebars = { version = "1.0.3", optional = true }
+handlebars = { version = "~1.0.3", optional = true }
 
 # async/await support
 tokio-async-await = { version = "0.1.4", optional = true }


### PR DESCRIPTION
Handlebars 1.0.x will work with Rust versions prior to 1.31. 

https://github.com/sunng87/handlebars-rust/issues/253