### PR TITLE
Parse content-type header value correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,11 @@ default = ["handlebars"]
 [dependencies]
 bytes = "0.4.7"
 futures = "0.1.21"
+headers = "0.2.0"
 http = "0.1.7"
 hyper = "0.12.1"
 log = "0.4.1"
+mime = "0.3.13"
 percent-encoding = "1.0.1"
 tokio = "0.1.6"
 tokio-fs = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,10 +467,12 @@ extern crate chrono;
 extern crate flate2;
 #[macro_use]
 extern crate futures;
+extern crate headers;
 extern crate http;
 extern crate hyper;
 #[macro_use]
 extern crate log;
+extern crate mime;
 extern crate percent_encoding;
 extern crate serde;
 extern crate serde_json;

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -148,6 +148,17 @@ fn extract_body_json_success() {
 }
 
 #[test]
+fn extract_body_json_success_charset() {
+    let mut web = service(TestExtract);
+
+    let body = r#"{"foo":"body bar"}"#;
+
+    let response = web.call_unwrap(post!("/extract_body", body, "content-type": "application/json;charset=utf-8"));
+    assert_ok!(response);
+    assert_body!(response, "extract_body");
+}
+
+#[test]
 fn extract_body_wrap_json_success() {
     let mut web = service(TestExtract);
 


### PR DESCRIPTION
The `headers` crate is now used to correctly parse the content-type
header. This fixes a bug where requests with JSON bodies would be
rejected if the content-type header value included a charset.