### PR TITLE
Fix `http` reference in macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - cargo test --lib --no-default-features
   - cargo test --tests --no-default-features
   - cargo test
-  - cargo test -p test_suite
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then cargo test -p test_suite; fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - cargo test --lib --no-default-features
   - cargo test --tests --no-default-features
   - cargo test
-  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then cargo test -p test_suite; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then cd test_suite && cargo test; fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - cargo test --lib --no-default-features
   - cargo test --tests --no-default-features
   - cargo test
+  - cargo test -p test_suite
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ categories = ["asynchronous", "web-programming::http-server"]
 members = [
   "./",
   "tower-web-macros",
-  "test_suite",
 ]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ categories = ["asynchronous", "web-programming::http-server"]
 members = [
   "./",
   "tower-web-macros",
+  "test_suite",
 ]
 
 [features]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test_suite"
+version = "0.1.0"
+authors = ["Carl Lerche <me@carllerche.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+tower-web = { path = "../" }
+serde = "1"

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 publish = false
 
+[workspace]
+
 [dependencies]
 tower-web = { path = "../" }
 serde = "1"

--- a/test_suite/tests/derive_rsponse.rs
+++ b/test_suite/tests/derive_rsponse.rs
@@ -1,0 +1,6 @@
+#[macro_use]
+extern crate tower_web;
+
+#[derive(Response)]
+pub struct Routes {}
+

--- a/tower-web-macros/src/derive/response.rs
+++ b/tower-web-macros/src/derive/response.rs
@@ -294,7 +294,7 @@ impl Response {
 
                         // TODO: Improve and handle errors
                         let body: __tw::codegen::bytes::Bytes = context.serialize(&Lift(&self), &serializer_context)
-                            .map_err(|_| __tw::Error::from(http::status::StatusCode::INTERNAL_SERVER_ERROR))?;
+                            .map_err(|_| __tw::Error::from(__tw::codegen::http::status::StatusCode::INTERNAL_SERVER_ERROR))?;
 
                         let body = __tw::error::Map::new(body);
 


### PR DESCRIPTION
Fixes an issue in the code generated by `derive(Response)` when using Rust 2018.

Ref: #183