### PR TITLE
Move the experimental await support to a different file

### DIFF
--- a/src/codegen/async_await.rs
+++ b/src/codegen/async_await.rs
@@ -1,0 +1,25 @@
+use futures::Future;
+
+use std::future::Future as StdFuture;
+
+/// Converts a `std::future::Future` to a boxed stable future.
+///
+/// This bridges async/await with stable futures.
+pub fn async_to_box_future_send<T>(
+    future: T,
+) -> Box<Future<Item = T::Output, Error = ::Error> + Send>
+where
+    T: StdFuture + Send + 'static,
+{
+    use tokio_async_await::compat::backward;
+
+    let future = backward::Compat::new(map_ok(future));
+    Box::new(future)
+}
+
+async fn map_ok<T, E>(future: T) -> Result<T::Output, E>
+where
+    T: StdFuture,
+{
+    Ok(await!(future))
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -31,29 +31,4 @@ pub mod serde {
 }
 
 #[cfg(feature = "async-await-preview")]
-pub mod async_await {
-    use futures::Future;
-
-    use std::future::{Future as StdFuture};
-
-    /// Converts a `std::future::Future` to a boxed stable future.
-    ///
-    /// This bridges async/await with stable futures.
-    pub fn async_to_box_future_send<T>(future: T)
-        -> Box<Future<Item = T::Output, Error = ::Error> + Send>
-    where
-        T: StdFuture + Send + 'static,
-    {
-        use tokio_async_await::compat::backward;
-
-        let future = backward::Compat::new(map_ok(future));
-        Box::new(future)
-    }
-
-    async fn map_ok<T, E>(future: T) -> Result<T::Output, E>
-    where
-        T: StdFuture,
-    {
-        Ok(await!(future))
-    }
-}
+pub mod async_await;


### PR DESCRIPTION
Partial fix for #192. Building with `async-await-preview` still doesn't work, though.