### PR TITLE
Add support for extracting the underlying http::Request

### DIFF
--- a/src/extract/http.rs
+++ b/src/extract/http.rs
@@ -1,0 +1,27 @@
+//! Permit the extraction of the underlying `http::Request` without the body.
+
+use http::Request;
+
+use extract::{Context, Error, Extract, Immediate};
+use util::BufStream;
+
+impl<B: BufStream> Extract<B> for Request<()> {
+    type Future = Immediate<Self>;
+
+    fn extract(ctx: &Context) -> Self::Future {
+        let request = Request::builder()
+            .version(ctx.request().version())
+            .method(ctx.request().method())
+            .uri(ctx.request().uri())
+            .body(())
+            .map_err(|e| Error::invalid_argument(&e))
+            .map(|mut request| {
+                request
+                    .headers_mut()
+                    .extend(ctx.request().headers().clone());
+                request
+            });
+
+        Immediate::result(request)
+    }
+}

--- a/src/extract/http_date_time.rs
+++ b/src/extract/http_date_time.rs
@@ -1,4 +1,5 @@
 //! HTTP combined date and time value.
+
 use chrono::{DateTime, Timelike, Utc};
 use extract::{Context, Error, Extract, Immediate};
 use http::{self, header};

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -25,15 +25,16 @@
 mod bytes;
 mod context;
 mod error;
+pub mod http_date_time;
+mod http;
 mod immediate;
 mod num;
 pub mod option;
+mod osstring;
 mod pathbuf;
 #[doc(hidden)]
 pub mod serde;
 mod str;
-mod osstring;
-pub mod http_date_time;
 
 pub use self::error::Error;
 pub use self::context::Context;

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -121,6 +121,16 @@ impl_web! {
             }"#).unwrap());
             Ok("extract_json")
         }
+
+        #[get("/extract_http_request")]
+        fn extract_http_request(&self, request: http::Request<()>) -> Result<&'static str, ()> {
+            assert_eq!(request.method(), http::Method::GET);
+            assert_eq!(request.body(), &());
+            let mut headers = http::HeaderMap::new();
+            headers.insert(http::header::CONTENT_TYPE, "text/plain".parse().unwrap());
+            assert_eq!(request.headers(), &headers);
+            Ok("extract_http_request")
+        }
     }
 }
 
@@ -278,4 +288,13 @@ fn extract_json() {
 
     assert_ok!(response);
     assert_body!(response, "extract_json");
+}
+
+#[test]
+fn extract_http_request() {
+    let mut web = service(TestExtract);
+
+    let response = web.call_unwrap(get!("/extract_http_request", "content-type": "text/plain"));
+    assert_ok!(response);
+    assert_body!(response, "extract_http_request");
 }


### PR DESCRIPTION
### Added

* Add `src/extract/http.rs` module with `Extract` implementation.
* Add `extract_http_request()` test in `tests/extract.rs`.

### Changed

* Minor formatting tweaks in `src/extract/mod.rs` and `src/extract/http_date_time.rs`.

Fixes #140.